### PR TITLE
Fix moving hazards and link levels

### DIFF
--- a/levels/level_3.tscn
+++ b/levels/level_3.tscn
@@ -11,7 +11,7 @@ albedo_color = Color(0.28975, 0.408702, 1, 1)
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ev7sl"]
 albedo_color = Color(0, 0.737255, 0.321569, 1)
 
-[node name="Level" type="Node3D"]
+[node name="Level2" type="Node3D"]
 
 [node name="LaunchPad" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 0.1, 0.005)

--- a/levels/level_4.tscn
+++ b/levels/level_4.tscn
@@ -35,13 +35,11 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 1.2, 0.005)
 
 [node name="MovingHazard" parent="." instance=ExtResource("3_viee3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.14345, 1.8113, 0)
-destination = Vector3(0, 7, 0)
-duration = 3.0
+desired_position = Vector3(0, 8, 0)
 
 [node name="MovingHazard2" parent="." instance=ExtResource("3_viee3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.67474, 1.8113, 0)
-destination = Vector3(0, 7, 0)
-duration = 3.0
+desired_position = Vector3(0, 7, 0)
 
 [node name="Obstacle" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.003, 4.9656, 0.035)

--- a/levels/level_5.tscn
+++ b/levels/level_5.tscn
@@ -14,7 +14,7 @@ albedo_color = Color(0, 0.737255, 0.321569, 1)
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4jfft"]
 albedo_color = Color(0.348827, 0.433489, 0.944039, 1)
 
-[node name="Level" type="Node3D"]
+[node name="Level2" type="Node3D"]
 
 [node name="LaunchPad" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 0.1, 0.005)
@@ -28,20 +28,18 @@ use_collision = true
 size = Vector3(3, 0.2, 3)
 material = SubResource("StandardMaterial3D_ev7sl")
 script = ExtResource("1_tbnwg")
-file_path = "res://levels/level.tscn"
+file_path = "res://levels/level_6.tscn"
 
 [node name="Player" parent="." instance=ExtResource("2_823ak")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 1.2, 0.005)
 
 [node name="MovingHazard" parent="." instance=ExtResource("3_xq7h4")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.14345, 1.8113, 0)
-destination = Vector3(0, 7, 0)
-duration = 3.0
+desired_position = Vector3(0, 5, 0)
 
 [node name="MovingHazard2" parent="." instance=ExtResource("3_xq7h4")]
 transform = Transform3D(0.395629, 0, 0, 0, 0.364669, 0, 0, 0, 1, -11.4505, 6.25543, 0.0828445)
-destination = Vector3(0, -5, 0)
-duration = 3.0
+desired_position = Vector3(0, -10, 0)
 
 [node name="Obstacle" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.003, 8.69225, 0.035)

--- a/levels/level_6.tscn
+++ b/levels/level_6.tscn
@@ -27,7 +27,7 @@ use_collision = true
 size = Vector3(3, 0.2, 3)
 material = SubResource("StandardMaterial3D_ev7sl")
 script = ExtResource("1_ow586")
-file_path = "res://levels/level_2.tscn"
+file_path = "res://levels/level_7.tscn"
 
 [node name="Obstacle" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.234, 4.27634, -0.374578)

--- a/levels/level_7.tscn
+++ b/levels/level_7.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://levels/landing_pad.gd" id="1_oki3o"]
 [ext_resource type="PackedScene" uid="uid://brs3why3rugsi" path="res://scenes/player/player.tscn" id="2_v3s7f"]
-[ext_resource type="PackedScene" uid="uid://kalepd6o3gdx" path="res://scenes/environment_test.tscn" id="3_sfndi"]
+[ext_resource type="PackedScene" uid="uid://it6majhd2sqd" path="res://scenes/environment_test.tscn" id="3_sfndi"]
 [ext_resource type="PackedScene" uid="uid://bexur4xjjutc" path="res://scenes/moving_hazard.tscn" id="4_f1nrb"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_340e8"]
@@ -28,7 +28,7 @@ use_collision = true
 size = Vector3(3, 0.2, 3)
 material = SubResource("StandardMaterial3D_ev7sl")
 script = ExtResource("1_oki3o")
-file_path = "res://levels/level_2.tscn"
+file_path = "res://levels/level.tscn"
 
 [node name="Obstacle" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.234, 4.27634, -0.374578)
@@ -45,20 +45,21 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.308733, -4.00356, -0.527797
 
 [node name="MovingHazard" parent="." instance=ExtResource("4_f1nrb")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.57231, 1.8113, 0)
-destination = Vector3(0, 7, 0)
-duration = 3.0
+desired_position = Vector3(0, 7, 0)
+transform_duration = 2.0
 
 [node name="MovingHazard3" parent="." instance=ExtResource("4_f1nrb")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.1597, 1.8113, 0)
-destination = Vector3(5, 7, 0)
-duration = 3.0
+desired_position = Vector3(0, 8, 0)
+desired_rotation = Vector3(30, 360, 0)
+transform_duration = 2.0
 
 [node name="MovingHazard2" parent="." instance=ExtResource("4_f1nrb")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.5169, 11.2946, 0)
-destination = Vector3(-20, 0, 0)
-duration = 3.0
+desired_position = Vector3(0, -7, 0)
+transform_duration = 2.0
 
 [node name="MovingHazard4" parent="." instance=ExtResource("4_f1nrb")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.65087, 11.2946, 0)
-destination = Vector3(7, 0, 0)
-duration = 3.0
+desired_position = Vector3(0, -8, 0)
+transform_duration = 2.0


### PR DESCRIPTION
Adjust the properties of moving hazards and update level references to ensure correct positioning and functionality within the game environment.