### PR TITLE
Centralize level transition logic and remove debug warning

### DIFF
--- a/scenes/player/effects_controller.gd
+++ b/scenes/player/effects_controller.gd
@@ -23,7 +23,6 @@ func connect_signals():
 	if parent:
 		parent.crashed.connect(_on_crashed)
 		parent.crash_ended.connect(_on_crash_ended)
-		parent.level_finished.connect(_on_level_finished)
 		parent.landing_state_changed.connect(_on_landing_state_changed)
 		parent.movement.boost_activated.connect(_on_boost_activated)
 

--- a/scenes/player/landing_controller.gd
+++ b/scenes/player/landing_controller.gd
@@ -47,12 +47,8 @@ func handle_successful_landing():
 
 	if landing_pad is TriggerPad:
 		landing_pad.activate_pad()
-
-	if landing_pad.has_method("get_next_level_path"):
-		var next_level = landing_pad.get_next_level_path()
-		if not next_level.is_empty():
-			parent.level_finished.emit(next_level)
-			successful_landing.emit()
+		
+	successful_landing.emit()
 
 func is_landing_stable() -> bool:
 	var current_velocity = parent.linear_velocity.length()

--- a/scenes/player/movement_controller.gd
+++ b/scenes/player/movement_controller.gd
@@ -55,7 +55,7 @@ func process_rotation(delta: float) -> void:
 	parent.effects.update_rotation_effects(rotation_direction)
 
 # Thrust-related methods
-func apply_thrust_force(delta: float) -> void:
+func apply_thrust_force(_delta: float) -> void:
 	var thrust_force = calculate_dampened_force(
 		parent.thrust,
 		parent.max_velocity,
@@ -81,7 +81,7 @@ func activate_boost() -> void:
 	consume_boost_fuel()
 	boost_activated.emit()
 
-func apply_boost_force(delta: float) -> void:
+func apply_boost_force(_delta: float) -> void:
 	var boost_force = calculate_dampened_force(
 		parent.boost_thrust,
 		parent.max_velocity * 1.5,  # Allow higher speed for boost


### PR DESCRIPTION
Centralize the logic for transitioning to the next level upon successful landing and eliminate unnecessary debug warnings in the code.