### PR TITLE
Adjust player scene dimensions and collision shapes for gameplay improvement

### DIFF
--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -21,7 +21,7 @@
 [ext_resource type="PackedScene" uid="uid://buxj68c16odaq" path="res://assets/models/rocket/scene.gltf" id="17_3kkwo"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_sg736"]
-height = 1.2
+height = 1.5
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_bc2uk"]
 height = 0.71
@@ -128,7 +128,7 @@ script = ExtResource("6_jxs5u")
 script = ExtResource("7_p66tl")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.603185, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.776183, 0)
 shape = SubResource("CylinderShape3D_sg736")
 
 [node name="CollisionShape3D3" type="CollisionShape3D" parent="."]


### PR DESCRIPTION
### **User description**
Closes #80

Enhance gameplay mechanics by modifying player scene dimensions and adjusting collision shape transforms.


___

### **PR Type**
Bug fix


___

### **Description**
- Adjusted the rocket's collision mesh height for better alignment.

- Modified collision shape transform to prevent sinking issues.

- Improved gameplay mechanics by refining collision dimensions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>player.tscn</strong><dd><code>Adjust collision mesh and transform for rocket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scenes/player/player.tscn

<li>Increased the height of the collision mesh.<br> <li> Adjusted the transform of the collision shape.<br> <li> Improved collision alignment to prevent sinking issues.


</details>


  </td>
  <td><a href="https://github.com/OutwardLightStudio/nexus/pull/81/files#diff-7e465a784e4eec5d6c4aaa366183aa47fb423c7685caf9f812bb3b1cf21616b0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>