### PR TITLE
Implement fuel depletion and boost deactivation effects

### DIFF
--- a/scenes/player/effects_controller.gd
+++ b/scenes/player/effects_controller.gd
@@ -24,7 +24,9 @@ func connect_signals():
 		parent.crashed.connect(_on_crashed)
 		parent.crash_ended.connect(_on_crash_ended)
 		parent.landing_state_changed.connect(_on_landing_state_changed)
-		parent.movement.boost_activated.connect(_on_boost_activated)
+		if parent.movement:
+			parent.movement.boost_activated.connect(_on_boost_activated)
+			parent.movement.connect("boost_deactivated", _on_boost_deactivated)
 
 # Crash effects
 func _on_crashed():
@@ -45,6 +47,9 @@ func _on_landing_state_changed(on_pad: bool):
 # Movement effects
 func _on_boost_activated():
 	play_boost_effects()
+
+func _on_boost_deactivated():
+	stop_boost_effects()
 
 func update_thrust_effects(is_thrusting: bool):
 	main_booster_particles.emitting = is_thrusting
@@ -74,3 +79,7 @@ func stop_success_effects():
 func play_boost_effects():
 	main_booster_particles.emitting = true
 	bubbles_sound.play()
+
+func stop_boost_effects():
+	main_booster_particles.emitting = false
+	bubbles_sound.stop()

--- a/scenes/player/effects_controller.gd
+++ b/scenes/player/effects_controller.gd
@@ -45,6 +45,9 @@ func _on_landing_state_changed(on_pad: bool):
 		stop_success_effects()
 
 # Movement effects
+func _on_fuel_depleted():
+	update_thrust_effects(false)
+
 func _on_boost_activated():
 	play_boost_effects()
 

--- a/scenes/player/movement_controller.gd
+++ b/scenes/player/movement_controller.gd
@@ -2,6 +2,7 @@ extends Node
 class_name MovementController
 
 signal boost_activated
+signal boost_deactivated
 
 @onready var parent: RocketController = get_parent() as RocketController
 @onready var e_button = get_parent().get_node("E_button")
@@ -121,6 +122,7 @@ func deactivate_boost() -> void:
 	parent.boosting = false
 	boost_timer = 0.0
 	parent.thrust_active = false
+	boost_deactivated.emit()
 
 func consume_boost_fuel() -> void:
 	parent.current_fuel -= parent.boost_fuel_cost

--- a/scenes/player/movement_controller.gd
+++ b/scenes/player/movement_controller.gd
@@ -151,7 +151,6 @@ func apply_force(force: float) -> void:
 func _on_fuel_depleted() -> void:
 	parent.is_thrusting = false
 	parent.thrust_active = false
-	parent.effects.update_thrust_effects(false)
 	
 	if is_boost_active:
 		deactivate_boost()

--- a/scenes/player/movement_controller.gd
+++ b/scenes/player/movement_controller.gd
@@ -151,6 +151,7 @@ func apply_force(force: float) -> void:
 func _on_fuel_depleted() -> void:
 	parent.is_thrusting = false
 	parent.thrust_active = false
+	parent.effects.update_thrust_effects(false)
 	
 	if is_boost_active:
 		deactivate_boost()


### PR DESCRIPTION
### **User description**
Closes #21

Introduce handling for boost deactivation and update thrust effects in response to fuel depletion within the movement and effects controllers.

This pull request introduces several new functionalities and improvements to the `effects_controller.gd` and `movement_controller.gd` scripts. The primary focus is on handling boost activation and deactivation events more effectively.

### Enhancements to boost functionality:

* [`scenes/player/effects_controller.gd`](diffhunk://#diff-71b1b2ebe223d9d86b1c54271302cc83e27178d7318bc29742088e8055f1ab31R27-R29): Added connections for `boost_activated` and `boost_deactivated` signals to handle boost effects. New methods `_on_boost_deactivated` and `stop_boost_effects` were introduced to stop boost effects when the boost is deactivated. [[1]](diffhunk://#diff-71b1b2ebe223d9d86b1c54271302cc83e27178d7318bc29742088e8055f1ab31R27-R29) [[2]](diffhunk://#diff-71b1b2ebe223d9d86b1c54271302cc83e27178d7318bc29742088e8055f1ab31R48-R56) [[3]](diffhunk://#diff-71b1b2ebe223d9d86b1c54271302cc83e27178d7318bc29742088e8055f1ab31R85-R88)

### Signal additions and emissions:

* [`scenes/player/movement_controller.gd`](diffhunk://#diff-86b505debbb05a428c4c024db26e68332659ef28556cbf123cc1736bbe789588R5): Added a new signal `boost_deactivated` and emitted this signal in the `deactivate_boost` method to notify when boost is deactivated. [[1]](diffhunk://#diff-86b505debbb05a428c4c024db26e68332659ef28556cbf123cc1736bbe789588R5) [[2]](diffhunk://#diff-86b505debbb05a428c4c024db26e68332659ef28556cbf123cc1736bbe789588R125)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed bug where boost particles continued after boost deactivation.

- Added `boost_deactivated` signal to `MovementController` for better event handling.

- Implemented `stop_boost_effects` in `EffectsController` to stop particles and sound.

- Enhanced signal connections and particle state updates for thrust effects.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>effects_controller.gd</strong><dd><code>Handle boost deactivation and update particle effects</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scenes/player/effects_controller.gd

<li>Added connection for <code>boost_deactivated</code> signal.<br> <li> Implemented <code>_on_boost_deactivated</code> to stop boost effects.<br> <li> Added <code>stop_boost_effects</code> method to stop particles and sound.<br> <li> Updated thrust effects handling for fuel depletion.


</details>


  </td>
  <td><a href="https://github.com/OutwardLightStudio/nexus/pull/82/files#diff-71b1b2ebe223d9d86b1c54271302cc83e27178d7318bc29742088e8055f1ab31">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>movement_controller.gd</strong><dd><code>Add boost deactivation signal and emit it</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scenes/player/movement_controller.gd

<li>Added <code>boost_deactivated</code> signal to notify boost state changes.<br> <li> Emitted <code>boost_deactivated</code> in <code>deactivate_boost</code> method.


</details>


  </td>
  <td><a href="https://github.com/OutwardLightStudio/nexus/pull/82/files#diff-86b505debbb05a428c4c024db26e68332659ef28556cbf123cc1736bbe789588">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>