### PR TITLE
Refactor boost button press handling for clarity

### DIFF
--- a/scenes/ui/hud_controller.gd
+++ b/scenes/ui/hud_controller.gd
@@ -15,11 +15,17 @@ func _ready() -> void:
 		e_button.pressed.connect(_on_boost_button_pressed)
 
 func _on_boost_button_pressed() -> void:
-	# Simulate a keyboard "boost" press by sending an InputEventAction
-	var event = InputEventAction.new()
-	event.action = "boost"
-	event.pressed = true
-	Input.parse_input_event(event)
+	# Send boost press event
+	var press_event = InputEventAction.new()
+	press_event.action = "boost"
+	press_event.pressed = true
+	Input.parse_input_event(press_event)
+	
+	# Send boost release event immediately after
+	var release_event = InputEventAction.new()
+	release_event.action = "boost"
+	release_event.pressed = false
+	Input.parse_input_event(release_event)
 
 func show_boost_available() -> void:
 	if e_button:


### PR DESCRIPTION
### **User description**
Improve the clarity and structure of the boost button press handling by separating the press and release events into distinct actions.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored boost button press handling for clarity.

- Added immediate release event after boost press.

- Improved structure for handling input events.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hud_controller.gd</strong><dd><code>Refactor and fix boost button input handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scenes/ui/hud_controller.gd

<li>Refactored boost button press handling logic.<br> <li> Added a release event immediately after the press event.<br> <li> Improved code clarity by renaming variables for better readability.


</details>


  </td>
  <td><a href="https://github.com/OutwardLightStudio/nexus/pull/91/files#diff-3ea5a84b1de7b31849a8b73ea45ea3e23f67ca745d627583cf392010b17e2ba3">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>